### PR TITLE
エラーハンドリングの全体への適用

### DIFF
--- a/backend/internal/controllers/auth_controller.go
+++ b/backend/internal/controllers/auth_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"myapp/internal/config"
 	"myapp/internal/controllers/schema"
+	"myapp/internal/exception"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 	"net/http"
@@ -46,13 +47,13 @@ func SignUp(ctx *gin.Context) {
 
 	body := schema.SignUpRequest{}
 	if err := ctx.ShouldBindJSON(&body); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		ctx.Error(exception.ErrInvalidRequest)
 		return
 	}
 
 	user, err := usecase.Execute(body.Username, body.Password)
 	if err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		ctx.Error(err)
 		return
 	}
 

--- a/backend/internal/controllers/auth_controller.go
+++ b/backend/internal/controllers/auth_controller.go
@@ -20,13 +20,13 @@ func SignIn(ctx *gin.Context) {
 
 	body := schema.SignInRequest{}
 	if err := ctx.ShouldBindJSON(&body); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		ctx.Error(exception.ErrInvalidRequest)
 		return
 	}
 
 	user, token, err := usecase.Execute(body.Username, body.Password)
 	if err != nil {
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		ctx.Error(err)
 		return
 	}
 

--- a/backend/internal/controllers/controller_helper.go
+++ b/backend/internal/controllers/controller_helper.go
@@ -5,20 +5,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// TODO: delete after implementing error handling to post_controller.go
-type ErrorResponse struct {
-	Message string "json:`message`"
-}
-
 // TODO: delete after implementing dependency injection
 func DB(ctx *gin.Context) *gorm.DB {
 	return ctx.MustGet("db").(*gorm.DB)
-}
-
-// TODO: delete after implementing error handling to post_controller.go
-func handleError(ctx *gin.Context, status int, err error) {
-	res := ErrorResponse{
-		Message: err.Error(),
-	}
-	ctx.JSON(status, &res)
 }

--- a/backend/internal/controllers/controller_helper.go
+++ b/backend/internal/controllers/controller_helper.go
@@ -5,14 +5,17 @@ import (
 	"gorm.io/gorm"
 )
 
+// TODO: delete after implementing error handling to post_controller.go
 type ErrorResponse struct {
 	Message string "json:`message`"
 }
 
+// TODO: delete after implementing dependency injection
 func DB(ctx *gin.Context) *gorm.DB {
 	return ctx.MustGet("db").(*gorm.DB)
 }
 
+// TODO: delete after implementing error handling to post_controller.go
 func handleError(ctx *gin.Context, status int, err error) {
 	res := ErrorResponse{
 		Message: err.Error(),

--- a/backend/internal/controllers/hello_world_controller.go
+++ b/backend/internal/controllers/hello_world_controller.go
@@ -20,10 +20,10 @@ func HelloWorld(ctx *gin.Context) {
 	result, err := usecase.Execute(lang)
 	if err != nil {
 		ctx.Error(err)
-	} else if result != nil {
-		ctx.JSON(http.StatusOK, result)
-	} else {
+	} else if result == nil {
 		ctx.Error(exception.ErrNotFound)
+	} else {
+		ctx.JSON(http.StatusOK, result)
 	}
 }
 

--- a/backend/internal/controllers/post_controller.go
+++ b/backend/internal/controllers/post_controller.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	"errors"
+	"myapp/internal/exception"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 
@@ -13,10 +13,10 @@ func GetAllPosts(ctx *gin.Context) {
 	usecase := usecases.NewGetAllPostsUsecase(repository)
 	result, err := usecase.Execute()
 	if err != nil {
-		handleError(ctx, 500, err)
-	} else if result != nil {
-		ctx.JSON(200, result)
+		ctx.Error(err)
+	} else if result == nil {
+		ctx.Error(exception.ErrNotFound)
 	} else {
-		handleError(ctx, 404, errors.New("not found"))
+		ctx.JSON(200, result)
 	}
 }

--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"myapp/internal/controllers/schema"
+	"myapp/internal/exception"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 	"net/http"
@@ -18,12 +19,13 @@ func GetSignedInUser(ctx *gin.Context) {
 
 	username, exists := ctx.Get("username")
 	if !exists {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "username not found"})
+		ctx.Error(exception.ErrUnauthorized)
 		return
 	}
+
 	user, err := usecases.Execute(username.(string))
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		ctx.Error(err)
 		return
 	}
 

--- a/backend/internal/exception/exception.go
+++ b/backend/internal/exception/exception.go
@@ -20,8 +20,8 @@ var (
 	ErrDuplicateUser  = new(http.StatusBadRequest, "Duplicate User")
 	ErrInvalidQuery   = new(http.StatusBadRequest, "Invalid Query")
 	ErrInvalidRequest = new(http.StatusBadRequest, "Invalid Request")
-	ErrSigninFailed   = new(http.StatusBadRequest, "Signin Failed")
 	ErrUnauthorized   = new(http.StatusUnauthorized, "Unauthorized")
+	ErrSigninFailed   = new(http.StatusUnauthorized, "Signin Failed")
 	ErrNotFound       = new(http.StatusNotFound, "Not Found")
 	// 5xx: Server Error
 	ErrInternalServerError = new(500, "Internal Server Error")

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -2,37 +2,30 @@ package middleware
 
 import (
 	"myapp/internal/config"
+	"myapp/internal/exception"
 	"myapp/internal/utils"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
 func Authenticated(ctx *gin.Context) {
 	jwtToken, err := ctx.Cookie(config.CookieNameForJWT)
-
 	if err != nil {
-		ctx.JSON(http.StatusUnauthorized, gin.H{
-			"message": "Unauthorized",
-		})
+		ctx.Error(exception.ErrUnauthorized)
 		ctx.Abort()
 		return
 	}
 
 	parsedToken, err := utils.ParseToken(jwtToken)
 	if err != nil {
-		ctx.JSON(http.StatusUnauthorized, gin.H{
-			"message": "Unauthorized",
-		})
+		ctx.Error(exception.ErrUnauthorized)
 		ctx.Abort()
 		return
 	}
 
 	username, err := utils.GetUsernameFromParsedToken(parsedToken)
 	if err != nil {
-		ctx.JSON(http.StatusUnauthorized, gin.H{
-			"message": "Unauthorized",
-		})
+		ctx.Error(exception.ErrUnauthorized)
 		ctx.Abort()
 		return
 	}

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -28,7 +28,7 @@ func (r *UserRepository) GetByUsername(username string) (*entities.User, error) 
 	var user User
 	if err := r.Conn.Where("name = ?", username).First(&user).Error; err != nil {
 		if err == gorm.ErrRecordNotFound {
-			return nil, fmt.Errorf("user not found")
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -1,8 +1,9 @@
 package repositories
 
 import (
-	"errors"
+	"fmt"
 	"myapp/internal/entities"
+	"myapp/internal/exception"
 
 	"github.com/go-sql-driver/mysql"
 	"gorm.io/gorm"
@@ -41,12 +42,12 @@ func (r *UserRepository) CreateUser(username, password string) (*entities.User, 
 		if mysqlErr, ok := result.Error.(*mysql.MySQLError); ok {
 			switch mysqlErr.Number {
 			case 1062:
-				return nil, errors.New("this username is already exists")
+				return nil, exception.ErrDuplicateUser
 			default:
-				return nil, errors.New("failed to create user due to unknown mysql error: " + mysqlErr.Error())
+				return nil, fmt.Errorf("failed to create user due to mysql error: %w", result.Error)
 			}
 		} else {
-			return nil, errors.New("failed to create user: " + result.Error.Error())
+			return nil, fmt.Errorf("failed to create user: %w", result.Error)
 		}
 	}
 

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -39,17 +39,16 @@ func (r *UserRepository) GetByUsername(username string) (*entities.User, error) 
 func (r *UserRepository) CreateUser(username, password string) (*entities.User, error) {
 	user := User{Name: username, Password: password}
 
-	result := r.Conn.Create(&user)
-	if result.Error != nil {
-		if mysqlErr, ok := result.Error.(*mysql.MySQLError); ok {
+	if err := r.Conn.Create(&user).Error; err != nil {
+		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
 			switch mysqlErr.Number {
 			case 1062:
 				return nil, fmt.Errorf("user already exists")
 			default:
-				return nil, result.Error
+				return nil, err
 			}
 		} else {
-			return nil, result.Error
+			return nil, err
 		}
 	}
 

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -28,6 +28,9 @@ func NewUserRepository(conn *gorm.DB) *UserRepository {
 func (r *UserRepository) GetByUsername(username string) (*entities.User, error) {
 	var user User
 	if err := r.Conn.Where("name = ?", username).First(&user).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, fmt.Errorf("user not found")
+		}
 		return nil, err
 	}
 

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"fmt"
 	"myapp/internal/entities"
-	"myapp/internal/exception"
 
 	"github.com/go-sql-driver/mysql"
 	"gorm.io/gorm"
@@ -45,7 +44,7 @@ func (r *UserRepository) CreateUser(username, password string) (*entities.User, 
 		if mysqlErr, ok := result.Error.(*mysql.MySQLError); ok {
 			switch mysqlErr.Number {
 			case 1062:
-				return nil, exception.ErrDuplicateUser
+				return nil, fmt.Errorf("user already exists")
 			default:
 				return nil, fmt.Errorf("failed to create user due to mysql error: %w", result.Error)
 			}

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -46,10 +46,10 @@ func (r *UserRepository) CreateUser(username, password string) (*entities.User, 
 			case 1062:
 				return nil, fmt.Errorf("user already exists")
 			default:
-				return nil, fmt.Errorf("failed to create user due to mysql error: %w", result.Error)
+				return nil, result.Error
 			}
 		} else {
-			return nil, fmt.Errorf("failed to create user: %w", result.Error)
+			return nil, result.Error
 		}
 	}
 

--- a/backend/internal/usecases/get_all_post_usecase.go
+++ b/backend/internal/usecases/get_all_post_usecase.go
@@ -17,7 +17,6 @@ func NewGetAllPostsUsecase(r interfaces.PostRepository) *GetAllPostsUsecase {
 
 func (u *GetAllPostsUsecase) Execute() ([]*entities.Post, error) {
 	result, err := u.repository.GetAll()
-
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecases/signin_usecase.go
+++ b/backend/internal/usecases/signin_usecase.go
@@ -1,7 +1,6 @@
 package usecases
 
 import (
-	"fmt"
 	"myapp/internal/entities"
 	"myapp/internal/exception"
 	"myapp/internal/interfaces"
@@ -26,7 +25,7 @@ func (u *SignInUsecase) Execute(username, password string) (*entities.User, stri
 	// Get user by username
 	user, err := u.repository.GetByUsername(username)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to get user by username: %w", err)
+		return nil, "", err
 	}
 
 	// Check if user is nil
@@ -43,7 +42,7 @@ func (u *SignInUsecase) Execute(username, password string) (*entities.User, stri
 	timeToExpire := time.Now().Add(time.Hour * 24).Unix()
 	token, err := utils.CreateToken(username, timeToExpire)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to create token: %w", err)
+		return nil, "", err
 	}
 
 	return user, token, nil

--- a/backend/internal/usecases/signin_usecase.go
+++ b/backend/internal/usecases/signin_usecase.go
@@ -26,10 +26,12 @@ func (u *SignInUsecase) Execute(username, password string) (*entities.User, stri
 	// Get user by username
 	user, err := u.repository.GetByUsername(username)
 	if err != nil {
-		if err.Error() == "user not found" {
-			return nil, "", exception.ErrSigninFailed
-		}
 		return nil, "", fmt.Errorf("failed to get user by username: %w", err)
+	}
+
+	// Check if user is nil
+	if user == nil {
+		return nil, "", exception.ErrSigninFailed
 	}
 
 	// Check password

--- a/backend/internal/usecases/signup_usecase.go
+++ b/backend/internal/usecases/signup_usecase.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"myapp/internal/entities"
+	"myapp/internal/exception"
 	"myapp/internal/interfaces"
 )
 
@@ -19,5 +20,12 @@ func NewSignUpUsecase(r interfaces.UserRepository) *SignUpUsecase {
 // Check if username is unique
 // If the username is valid, create user and return user entity
 func (u *SignUpUsecase) Execute(username, password string) (*entities.User, error) {
-	return u.repository.CreateUser(username, password)
+	user, err := u.repository.CreateUser(username, password)
+	if err != nil {
+		if err.Error() == "user already exists" {
+			return nil, exception.ErrDuplicateUser
+		}
+		return nil, err
+	}
+	return user, nil
 }

--- a/backend/internal/usecases/signup_usecase.go
+++ b/backend/internal/usecases/signup_usecase.go
@@ -19,9 +19,5 @@ func NewSignUpUsecase(r interfaces.UserRepository) *SignUpUsecase {
 // Check if username is unique
 // If the username is valid, create user and return user entity
 func (u *SignUpUsecase) Execute(username, password string) (*entities.User, error) {
-	user, err := u.repository.CreateUser(username, password)
-	if err != nil {
-		return nil, err
-	}
-	return user, nil
+	return u.repository.CreateUser(username, password)
 }


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

#47 

## PRの概要
### 現状
<!-- 解決するべき課題　なければなし -->

エラーハンドリングが API ごとにバラバラ

### 今回やったこと
<!-- このPRでやったことの説明 -->

- 既存 API に #44 で導入されたエラーハンドリングを実装した
- 不要になった helper 類の削除

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->

### 動作検証
<!-- テストの実行結果やPlaygroundの実行結果のスクリーンショット等 -->

<details>
<summary>GET `/posts` の 500</summary>

posts テーブルを削除した状態で 500 が帰ってくる

![Screenshot 2024-06-24 at 13 03 25](https://github.com/givery-bootcamp/dena-2024-team10/assets/63628739/fbe87b58-4fdf-4e2a-9a9d-380e910ef9ae)

サーバのログには table doesn't exist

![Screenshot 2024-06-24 at 13 05 05](https://github.com/givery-bootcamp/dena-2024-team10/assets/63628739/17ff3dee-5d48-480e-89f2-7981d3680edf)

GET `/user` でも同様に確認した

</details>

<details>
<summary>GET `/signin` の 400</summary>

パスワード or ユーザ名が違う場合に 400 Signin failed を返している

![Screenshot 2024-06-24 at 16 40 51](https://github.com/givery-bootcamp/dena-2024-team10/assets/63628739/9e25e768-4127-426e-baff-0e9bd9cc9143)

</details>

<details>
<summary>GET `/signup` の 400</summary>

ユーザ名の重複時に 400 を返している

![Screenshot 2024-06-24 at 16 44 57](https://github.com/givery-bootcamp/dena-2024-team10/assets/63628739/06d44c31-95e1-4a6a-8586-fed21ec1101f)

</details>

<details>
<summary>Authorization middleware の 401</summary>

cookie を設定せずに認証が必要な API を叩くと 401 が帰ってくる
![Screenshot 2024-06-24 at 18 16 39](https://github.com/givery-bootcamp/dena-2024-team10/assets/63628739/4a975649-30ed-43f1-9ba0-128bc4d3a47e)

</details>

### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->