### PR TITLE
bugfix: 投稿が失敗した際の、無限エラー編突入バグの修正

### DIFF
--- a/frontend/app/routes/posts.new.tsx
+++ b/frontend/app/routes/posts.new.tsx
@@ -1,15 +1,14 @@
 import {
 	type ActionFunctionArgs,
-	redirect,
 	type SerializeFrom,
+	redirect,
 } from "@remix-run/node";
-import { Form, json, useActionData } from "@remix-run/react";
+import { Link, json, useActionData } from "@remix-run/react";
 import classNames from "classnames";
 import { ZodError } from "zod";
 import apiClient from "~/apiClient/apiClient";
 import { schemas } from "~/apiClient/output.generated";
 import PostForm from "~/components/postForm";
-import SubmitButton from "~/components/submitButton";
 
 export async function action({ request }: ActionFunctionArgs) {
 	try {
@@ -52,6 +51,20 @@ export default function () {
 		<main className={classNames("w-1/2", "mx-auto")}>
 			<h1 className={classNames("text-4xl", "my-4")}>新しい投稿を作成する</h1>
 			<PostForm actionData={actionData} />
+		</main>
+	);
+}
+
+export function ErrorBoundary() {
+	return (
+		<main className={classNames("w-1/2", "mx-auto")}>
+			<h1 className={classNames("text-4xl", "my-4")}>投稿に失敗しました</h1>
+			<p>しばらく待ってからやり直してください</p>
+			<div className={classNames("text-end", "mr-5")}>
+				<Link to="/" className={classNames("text-blue-600", "underline")}>
+					一覧ページへ
+				</Link>
+			</div>
 		</main>
 	);
 }


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

## PRの概要
### 現状
<!-- 解決するべき課題　なければなし -->
/posts/new で投稿ボタンを押し、リクエスト送信後にエラーが発生すると、cosoleに無限に無言のエラーが吐かれ続ける

### 今回やったこと
<!-- このPRでやったことの説明 -->
- fetchで発生したエラーは、try/catchでcatchされ、500レスポンスとしてthrowされているようになっている
- ここでthrowされたものは、root.tsのErrorBoundaryでキャッチされ、エラーページが表示される予定だった
- しかし、表示されなかった
- そこで、**posts.newにErrorBoundaryを宣言してみたところ、正常にエラーページを表示することができたため、今回はこの対応で行く**

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->

### 動作検証
<!-- テストの実行結果やPlaygroundの実行結果のスクリーンショット等 -->

https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/f6786b4c-c24a-419d-89ea-ef90ebbfbf50



### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->