### PR TITLE
【フロント】サインアップのロジック作成、サインイン失敗時にrootに遷移しちゃう問題解消

### DIFF
--- a/frontend/app/components/authForm.tsx
+++ b/frontend/app/components/authForm.tsx
@@ -1,53 +1,71 @@
 import { Form } from "@remix-run/react";
 import classNames from "classnames";
+import type { AuthErrorType } from "~/routes/signup";
 
-const AuthForm = ({ authType }: { authType: string }) => {
+const AuthForm = ({
+	authType,
+	actionData,
+}: { authType: string; actionData: AuthErrorType }) => {
 	return (
-		<Form method="post">
-			<div className={classNames("my-5")}>
-				<label htmlFor="name" className={classNames("my-2", "block")}>
-					ユーザー名
-				</label>
+		<>
+			<Form method="post">
+				<div className={classNames("my-5")}>
+					<label htmlFor="name" className={classNames("my-2", "block")}>
+						ユーザー名
+					</label>
+					<input
+						id="name"
+						type="text"
+						name="name"
+						className={classNames(
+							"border-2",
+							"rounded-md",
+							"border-gray-300",
+							"w-full",
+						)}
+					/>
+				</div>
+				<div className={classNames("my-5")}>
+					<label htmlFor="pass" className={classNames("my-2", "block")}>
+						パスワード
+					</label>
+					<input
+						id="pass"
+						type="password"
+						name="pass"
+						className={classNames(
+							"border-2",
+							"rounded-md",
+							"border-gray-300",
+							"w-full",
+						)}
+					/>
+				</div>
 				<input
-					id="name"
-					type="text"
-					name="name"
+					type="submit"
+					value={authType === "signin" ? "サインイン" : "サインアップ"}
 					className={classNames(
-						"border-2",
+						"text-white",
+						authType === "signin" ? "bg-blue-600" : "bg-green-600",
+						"p-2",
 						"rounded-md",
-						"border-gray-300",
-						"w-full",
+						authType === "signin"
+							? "hover:bg-indigo-200"
+							: "hover:bg-green-200",
 					)}
 				/>
-			</div>
-			<div className={classNames("my-5")}>
-				<label htmlFor="pass" className={classNames("my-2", "block")}>
-					パスワード
-				</label>
-				<input
-					id="pass"
-					type="password"
-					name="pass"
-					className={classNames(
-						"border-2",
-						"rounded-md",
-						"border-gray-300",
-						"w-full",
-					)}
-				/>
-			</div>
-			<input
-				type="submit"
-				value={authType === "signin" ? "サインイン" : "サインアップ"}
-				className={classNames(
-					"text-white",
-					authType === "signin" ? "bg-blue-600" : "bg-green-600",
-					"p-2",
-					"rounded-md",
-					authType === "signin" ? "hover:bg-indigo-200" : "hover:bg-green-200",
-				)}
-			/>
-		</Form>
+			</Form>
+			{actionData?.errors && (
+				<ul>
+					{actionData.errors.map((error, i) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: <explanation>
+						<li key={i} className={classNames("text-red-500")}>
+							{error.path} : {error.message}
+						</li>
+					))}
+				</ul>
+			)}
+		</>
 	);
 };
 

--- a/frontend/app/components/baseInternalError.tsx
+++ b/frontend/app/components/baseInternalError.tsx
@@ -4,15 +4,15 @@ import classNames from "classnames";
 export default function InternalError({
 	title,
 	to,
-	toMessage,
-}: { title: string; to: string; toMessage: string }) {
+	toPageName,
+}: { title: string; to: string; toPageName: string }) {
 	return (
 		<main className={classNames("w-1/2", "mx-auto")}>
 			<h1 className={classNames("text-4xl", "my-4")}>{title}</h1>
 			<p>しばらく待ってからやり直してください</p>
 			<div className={classNames("text-end", "mr-5")}>
 				<Link to={to} className={classNames("text-blue-600", "underline")}>
-					{toMessage}
+					{toPageName}画面へ
 				</Link>
 			</div>
 		</main>

--- a/frontend/app/components/internalError.tsx
+++ b/frontend/app/components/internalError.tsx
@@ -1,0 +1,20 @@
+import { Link } from "@remix-run/react";
+import classNames from "classnames";
+
+export default function InternalError({
+	title,
+	to,
+	toMessage,
+}: { title: string; to: string; toMessage: string }) {
+	return (
+		<main className={classNames("w-1/2", "mx-auto")}>
+			<h1 className={classNames("text-4xl", "my-4")}>{title}</h1>
+			<p>しばらく待ってからやり直してください</p>
+			<div className={classNames("text-end", "mr-5")}>
+				<Link to={to} className={classNames("text-blue-600", "underline")}>
+					{toMessage}
+				</Link>
+			</div>
+		</main>
+	);
+}

--- a/frontend/app/routes/posts.new.tsx
+++ b/frontend/app/routes/posts.new.tsx
@@ -8,6 +8,7 @@ import classNames from "classnames";
 import { ZodError } from "zod";
 import apiClient from "~/apiClient/apiClient";
 import { schemas } from "~/apiClient/output.generated";
+import InternalError from "~/components/baseInternalError";
 import PostForm from "~/components/postForm";
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -56,15 +57,5 @@ export default function () {
 }
 
 export function ErrorBoundary() {
-	return (
-		<main className={classNames("w-1/2", "mx-auto")}>
-			<h1 className={classNames("text-4xl", "my-4")}>投稿に失敗しました</h1>
-			<p>しばらく待ってからやり直してください</p>
-			<div className={classNames("text-end", "mr-5")}>
-				<Link to="/" className={classNames("text-blue-600", "underline")}>
-					一覧ページへ
-				</Link>
-			</div>
-		</main>
-	);
+	return <InternalError title="投稿に失敗しました" to="/" toPageName="一覧" />;
 }

--- a/frontend/app/routes/signin.tsx
+++ b/frontend/app/routes/signin.tsx
@@ -4,8 +4,8 @@ import classNames from "classnames";
 import { ZodError } from "zod";
 import { API_BASE_URL } from "~/apiClient/apiClient";
 import { schemas } from "~/apiClient/output.generated";
-import InternalError from "~/components/InternalError";
 import AuthForm from "~/components/authForm";
+import InternalError from "~/components/baseInternalError";
 
 export async function action({ request }: ActionFunctionArgs) {
 	try {
@@ -79,7 +79,7 @@ export function ErrorBoundary() {
 		<InternalError
 			title="サインインに失敗しました"
 			to="/signin"
-			toMessage="サインイン画面へ戻る"
+			toPageName="サインイン"
 		/>
 	);
 }

--- a/frontend/app/routes/signin.tsx
+++ b/frontend/app/routes/signin.tsx
@@ -1,9 +1,10 @@
 import type { ActionFunctionArgs } from "@remix-run/node";
-import { Link, redirect } from "@remix-run/react";
+import { Link, json, redirect, useActionData } from "@remix-run/react";
 import classNames from "classnames";
 import { ZodError } from "zod";
-import apiClient, { API_BASE_URL } from "~/apiClient/apiClient";
+import { API_BASE_URL } from "~/apiClient/apiClient";
 import { schemas } from "~/apiClient/output.generated";
+import InternalError from "~/components/InternalError";
 import AuthForm from "~/components/authForm";
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -20,21 +21,42 @@ export async function action({ request }: ActionFunctionArgs) {
 				"content-type": "application/json",
 			},
 		});
+		if (res.status === 400) throw new Error("Invalid credentials");
+		if (!res.ok) throw new Error("Failed to sign in");
 
 		return redirect("/", {
 			headers: res.headers,
 		});
 	} catch (e) {
 		console.error(e);
-		if (e instanceof ZodError) return new Response(e.message, { status: 400 });
-		if (e instanceof Error) return new Response(e.toString(), { status: 500 });
+		if (e instanceof ZodError) {
+			return json({
+				errors: e.errors.map((error) => {
+					return { path: error.path, message: error.message };
+				}),
+			});
+		}
+		if (e instanceof Error) {
+			if (e.message === "Invalid credentials") {
+				return json({
+					errors: [
+						{
+							path: "credentials",
+							message: "ユーザー名またはパスワードが正しくありません",
+						},
+					],
+				});
+			}
+			throw new Response(e.toString(), { status: 500 });
+		}
 	}
 }
 
 export default function SignIn() {
+	const actionData = useActionData<typeof action>();
 	return (
 		<main className={classNames("mx-auto", "w-1/3")}>
-			<AuthForm authType="signin" />
+			<AuthForm authType="signin" actionData={actionData} />
 			<Link
 				to="/signup"
 				className={classNames(
@@ -49,5 +71,15 @@ export default function SignIn() {
 				アカウントをお持ちでない方はこちら
 			</Link>
 		</main>
+	);
+}
+
+export function ErrorBoundary() {
+	return (
+		<InternalError
+			title="サインインに失敗しました"
+			to="/signin"
+			toMessage="サインイン画面へ戻る"
+		/>
 	);
 }

--- a/frontend/app/routes/signup.tsx
+++ b/frontend/app/routes/signup.tsx
@@ -1,22 +1,64 @@
-import type { ActionFunctionArgs } from "@remix-run/node";
-import { Link } from "@remix-run/react";
+import type { ActionFunctionArgs, SerializeFrom } from "@remix-run/node";
+import { Link, json, redirect, useActionData } from "@remix-run/react";
 import classNames from "classnames";
+import { ZodError } from "zod";
+import { API_BASE_URL } from "~/apiClient/apiClient";
+import { schemas } from "~/apiClient/output.generated";
+import InternalError from "~/components/InternalError";
 import AuthForm from "~/components/authForm";
 
 export async function action({ request }: ActionFunctionArgs) {
-	const formData = await request.formData();
-	const name = formData.get("name");
-	const pass = formData.get("pass");
-	console.log(name, pass);
-	return new Response("サインアップしました", {
-		status: 200,
-	});
+	try {
+		const formData = await request.formData();
+		const username = formData.get("name") as string;
+		const password = formData.get("pass") as string;
+
+		const body = schemas.signupUser_Body.parse({ username, password });
+		const res = await fetch(`${API_BASE_URL}/signup`, {
+			method: "POST",
+			body: JSON.stringify(body),
+			headers: {
+				"content-type": "application/json",
+			},
+		});
+		if (res.status === 400) throw new Error("Duplicate username");
+		if (!res.ok) throw new Error("Failed to sign up");
+
+		return redirect("/", {
+			headers: res.headers,
+		});
+	} catch (e) {
+		console.error(e);
+		if (e instanceof ZodError) {
+			return json({
+				errors: e.errors.map((error) => {
+					return { path: error.path, message: error.message };
+				}),
+			});
+		}
+		if (e instanceof Error) {
+			if (e.message === "Duplicate username") {
+				return json({
+					errors: [
+						{
+							path: "username",
+							message: "このユーザー名はすでに使用されています",
+						},
+					],
+				});
+			}
+			throw new Response(e.toString(), { status: 500 });
+		}
+	}
 }
 
+export type AuthErrorType = SerializeFrom<typeof action> | undefined;
+
 export default function SignIn() {
+	const actionData = useActionData<typeof action>();
 	return (
 		<main className={classNames("mx-auto", "w-1/3")}>
-			<AuthForm authType="signup" />
+			<AuthForm authType="signup" actionData={actionData} />
 			<Link
 				to="/signin"
 				className={classNames(
@@ -31,5 +73,15 @@ export default function SignIn() {
 				アカウントをすでにお持ちの方はこちら
 			</Link>
 		</main>
+	);
+}
+
+export function ErrorBoundary() {
+	return (
+		<InternalError
+			title="サインアップに失敗しました"
+			to="/signup"
+			toMessage="サインアップ画面へ戻る"
+		/>
 	);
 }

--- a/frontend/app/routes/signup.tsx
+++ b/frontend/app/routes/signup.tsx
@@ -4,8 +4,8 @@ import classNames from "classnames";
 import { ZodError } from "zod";
 import { API_BASE_URL } from "~/apiClient/apiClient";
 import { schemas } from "~/apiClient/output.generated";
-import InternalError from "~/components/InternalError";
 import AuthForm from "~/components/authForm";
+import InternalError from "~/components/baseInternalError";
 
 export async function action({ request }: ActionFunctionArgs) {
 	try {
@@ -81,7 +81,7 @@ export function ErrorBoundary() {
 		<InternalError
 			title="サインアップに失敗しました"
 			to="/signup"
-			toMessage="サインアップ画面へ戻る"
+			toPageName="サインアップ"
 		/>
 	);
 }


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->
- Close #61 
- Close #60 

## PRの概要
### 現状
<!-- 解決するべき課題　なければなし -->
issueに書いてあるとおり

### 今回やったこと
<!-- このPRでやったことの説明 -->
- signup時にAPIを叩くように実装
  - 失敗時のエラーハンドリング実装
  - すでに使用しているユーザを作成しようとした時のエラーハンドリング実装
- signin失敗時にエラーメッセージをサインアップ画面に表示し、rootへ遷移しないように実装
- ErrorBoundary用のエラー画面コンポーネント作成・置き換え

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->
- root.tsxの中のErrorBoundary は置き換えてない

### 動作検証
<!-- テストの実行結果やPlaygroundの実行結果のスクリーンショット等 -->

**usernameがすでに使用されている**

https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/f497c136-25e2-493e-a36e-016d82224a4b

**サインアップが失敗する(500)**

https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/8554a1c6-3a2e-4309-995d-f9f3493a45f2

**サインインの情報が間違っている**

https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/75809968-00f5-49af-84d0-faa209a39e87

**サインインに失敗する(500)**


https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/1804a562-c32d-47d7-9a8b-45289304d5f3



### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->