### PR TITLE
投稿詳細APIを叩く

### DIFF
--- a/frontend/app/apiClient/output.generated.ts
+++ b/frontend/app/apiClient/output.generated.ts
@@ -41,6 +41,18 @@ const endpoints = makeApi([
     alias: "getPosts",
     description: `Retrieve a list of posts sorted by id in descending order.`,
     requestFormat: "json",
+    parameters: [
+      {
+        name: "limit",
+        type: "Query",
+        schema: z.number().int().gte(1).lte(100).optional().default(20),
+      },
+      {
+        name: "offset",
+        type: "Query",
+        schema: z.number().int().gte(0).optional().default(0),
+      },
+    ],
     response: z.array(Post),
     errors: [
       {
@@ -62,6 +74,21 @@ const endpoints = makeApi([
         description: `Post details needed for creation`,
         type: "Body",
         schema: createPost_Body,
+      },
+    ],
+    response: Post,
+  },
+  {
+    method: "get",
+    path: "/posts/:postId",
+    alias: "getPost",
+    description: `Retrieve a post by its ID.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "postId",
+        type: "Path",
+        schema: z.number().int(),
       },
     ],
     response: Post,

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -44,7 +44,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 				<Links />
 			</head>
 			<body>
-				<Header isSignedIn={!!user.id} username={user.username} />
+				<Header isSignedIn={!!user?.id} username={user?.username} />
 				{children}
 				<ScrollRestoration />
 				<Scripts />

--- a/frontend/app/routes/posts.$postId.tsx
+++ b/frontend/app/routes/posts.$postId.tsx
@@ -16,19 +16,19 @@ import formatDate from "utils/formatDate";
 import apiClient from "~/apiClient/apiClient";
 import Dialog, { useDialog } from "~/components/dialog";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ params, request }: LoaderFunctionArgs) {
 	try {
-		// const detailes = await apiClient.getPostDetails(id: params.postId);
-		// return json({ detailes });
-		return json({
-			id: params.postId,
-			title: "title",
-			body: "body\n\nboooddddyyyyyy",
-			user_id: 1,
-			username: "username",
-			created_at: "2022-01-01T00:00:00.000Z",
-			updated_at: "2022-01-01T00:00:00.000Z",
+		const postId = Number.parseInt(params.postId as string);
+		const post = await apiClient.getPost({
+			params: {
+				postId,
+			},
+			headers: {
+				Cookie: request.headers.get("Cookie"),
+			},
 		});
+
+		return post;
 	} catch (error) {
 		console.error(error);
 		if (error instanceof Error) {

--- a/frontend/app/routes/posts.$postId_.edit.tsx
+++ b/frontend/app/routes/posts.$postId_.edit.tsx
@@ -13,16 +13,27 @@ import PostForm from "~/components/postForm";
 import SubmitButton from "~/components/submitButton";
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
-	const postId = Number.parseInt(params.postId as string);
-	return json({
-		id: postId,
-		title: "title",
-		body: "body\n\nboooddddyyyyyy",
-		user_id: 1,
-		username: "username",
-		created_at: "2022-01-01T00:00:00.000Z",
-		updated_at: "2022-01-01T00:00:00.000Z",
-	});
+	try {
+		const postId = Number.parseInt(params.postId as string);
+		const post = await apiClient.getPost({
+			params: {
+				postId,
+			},
+			headers: {
+				Cookie: request.headers.get("Cookie"),
+			},
+		});
+
+		return post;
+	} catch (error) {
+		console.error(error);
+		if (error instanceof Error) {
+			throw new Response(`name: ${error.name}, message: ${error.message}`, {
+				status: 500,
+			});
+		}
+		throw new Response("エラーが発生しました", { status: 500 });
+	}
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

## PRの概要
### 現状
バックエンドに、投稿詳細APIがないため、投稿詳細の画面はモックの情報が出ている。

### 今回やったこと
投稿詳細が実装されたので
投稿詳細画面で、対応するバックエンドのAPIを叩くように更新した。

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->

### 動作検証
バックエンドと合わせて投稿詳細画面が表示されることを確認した
<img width="677" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team10/assets/17082836/4d7765cb-ab8c-4e02-8de9-791a547dcf92">

### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->