### PR TITLE
[front::bigfix] Postsがlimitより少ないと、同じデータを２回fetchしてしまうバグの解消

### DIFF
--- a/frontend/app/hooks/infinitieLoading.ts
+++ b/frontend/app/hooks/infinitieLoading.ts
@@ -20,7 +20,7 @@ export function useInfinitieLoading<T, U>(
 	// 取得したすべての要素を保持する配列
 	const [list, setList] = useState<U[]>(extractArrayData(initialData));
 
-	const [hasNoMoreItems, setHasNoMoreItems] = useState(false);
+	const [hasNoMoreItems, setHasNoMoreItems] = useState(list.length < limit);
 
 	// fetcherが新しい要素を読み込んだら配列に追加
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

## PRの概要
### 現状
<!-- 解決するべき課題　なければなし -->
Postsの数がlimitよりも少ないと、同じデータを２回fetchしてしまう

![image](https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/92b6682e-2b6e-48fc-9b71-253a0e6af7cf)


### 今回やったこと
<!-- このPRでやったことの説明 -->
~~hasNoMoreItemsをtureにするタイミングが、loadNextが叩かれるタイミングに依存しているため、hasNoMoreItemsのinitに常にfalseを入れていると、最初の取得でlimitよりも少ない数を取得してきた時に、最初にとってきたデータをもう一度とってきてしまうことになるので、修正~~　ーー＞  本番環境だったらoffsetがちゃんと機能するして、空配列が帰ってくるから、問題ないのか

でも、せっかく考えたので ↓ ということで 🙇

Posts全体の数がlimitより少なくて、最初の取得で全体が取得できていた時に、要らないリクエストを投げてしまうことになっているので、修正

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->

### 動作検証
<!-- テストの実行結果やPlaygroundの実行結果のスクリーンショット等 -->

![image](https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/c9202260-1e59-48e3-bd90-0f41a7167219)



### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [x] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->