### PR TITLE
[front] 詳細ページから一覧ページに戻るためのボタン実装

### DIFF
--- a/frontend/app/components/header.tsx
+++ b/frontend/app/components/header.tsx
@@ -10,8 +10,8 @@ export default function Header({
 		<header
 			className={classNames("bg-blue-800", "p-2", "flex", "items-center")}
 		>
-			<h1 className={classNames("text-lg", "text-white", "flex-1")}>
-				サンプルアプリケーション
+			<h1 className={classNames("text-lg", "text-white", "flex-1", "ml-4")}>
+				<Link to="/">team-10 絆の掲示板アプリ</Link>
 			</h1>
 			{isSignedIn ? (
 				<>

--- a/frontend/app/routes/posts.$postId.tsx
+++ b/frontend/app/routes/posts.$postId.tsx
@@ -1,7 +1,7 @@
 import {
 	type ActionFunctionArgs,
-	json,
 	type LoaderFunctionArgs,
+	json,
 } from "@remix-run/node";
 import {
 	Form,
@@ -75,7 +75,21 @@ export default function PostsDetails() {
 	);
 	return (
 		<main className={classNames("mx-auto", "w-1/2")}>
-			<h1 className={classNames("text-3xl", "my-3")}>{data.title}</h1>
+			<div className={classNames("flex")}>
+				<Link
+					to="/"
+					className={classNames(
+						"-ml-24",
+						"mr-8",
+						"mt-4",
+						"text-gray-300",
+						"hover:text-gray-500",
+					)}
+				>
+					＜一覧へ
+				</Link>
+				<h1 className={classNames("text-3xl", "my-3")}>{data.title}</h1>
+			</div>
 			<div className={classNames("flex", "gap-3")}>
 				{TimeTopic("作成日時", data.created_at)}
 				{TimeTopic("更新日時", data.updated_at)}


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->
 Close #57 

## PRの概要
### 現状
<!-- 解決するべき課題　なければなし -->
詳細ページにいったら一覧ページに戻れん(アプリ純正機能で)

### 今回やったこと
<!-- このPRでやったことの説明 -->
- 詳細画面に一覧に戻るボタン実装
- ついで
  - ヘッダーのアプリケーション名を押すとトップに遷移するように実装
  - （名前も変えちゃったw^^w）

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->

### 動作検証
<!-- テストの実行結果やPlaygroundの実行結果のスクリーンショット等 -->

https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/8a71080d-635f-4b5c-b0ec-7d3e6603ed7a



### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->