### PR TITLE
rootのエラーハンドリングをリッチにした

### DIFF
--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -1,10 +1,16 @@
-import type { LinksFunction, LoaderFunctionArgs } from "@remix-run/node";
+import type {
+	ErrorResponse,
+	LinksFunction,
+	LoaderFunctionArgs,
+} from "@remix-run/node";
 import {
+	Link,
 	Links,
 	Meta,
 	Outlet,
 	Scripts,
 	ScrollRestoration,
+	isRouteErrorResponse,
 	redirect,
 	useLoaderData,
 	useRouteError,
@@ -66,11 +72,39 @@ export function Layout({ children }: { children: React.ReactNode }) {
 
 export function ErrorBoundary() {
 	const error = useRouteError();
-	console.error(error);
+	type MyRouteError = {
+		type: "MyRouteError";
+		status: number;
+		data: string;
+		string: string;
+	};
+	const errorResponseToMyRouteError = (error: ErrorResponse): MyRouteError => {
+		const { status, data } = error;
+		return {
+			type: "MyRouteError",
+			status,
+			data,
+			string: JSON.stringify(error),
+		};
+	};
+	let title = "Oops!";
+	let message = "Something went wrong!";
+	const toMessage = "Go to Top Page";
+	const toLink = "/";
+
+	if (isRouteErrorResponse(error)) {
+		if (error.status === 404) {
+			title = "Page Not Found";
+			message = "Sorry, we couldn't find the page you're looking for.";
+		}
+		console.error(JSON.stringify(errorResponseToMyRouteError(error)));
+	} else {
+		console.error(JSON.stringify(error));
+	}
 	return (
 		<html lang="ja">
 			<head>
-				<title>Oh no!</title>
+				<title>{title}</title>
 				<Meta />
 				<Links />
 			</head>
@@ -85,8 +119,20 @@ export function ErrorBoundary() {
 						"mt-8",
 					)}
 				>
-					Oh no!
+					{title}
 				</h1>
+				<p className={classNames("text-center", "mt-4")}>{message}</p>
+				<p
+					className={classNames(
+						"text-center",
+						"mt-4",
+						"text-blue-600",
+						"underline",
+						"hover:text-blue-300",
+					)}
+				>
+					<Link to={toLink}>{toMessage}</Link>
+				</p>
 				<Scripts />
 			</body>
 		</html>


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

## PRの概要
### 現状
<!-- 解決するべき課題　なければなし -->
rootのErrorBoundaryに引っかかった時、Oh,no!って赤字で出されても困るので、もうちょっとどうにかする

### 今回やったこと
<!-- このPRでやったことの説明 -->
- rootのError Boundaryをリッチに
- 404に対応

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->
`/posts`は`/`にリダイレクトしてもいいなと思った

### 動作検証
<!-- テストの実行結果やPlaygroundの実行結果のスクリーンショット等 -->

https://github.com/givery-bootcamp/dena-2024-team10/assets/74412997/70765e50-2f16-478d-a6d3-755b4013dfc0



### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->