### PR TITLE
投稿更新時のレスポンスにIDが含まれるようにした

### DIFF
--- a/backend/internal/repositories/post_repository.go
+++ b/backend/internal/repositories/post_repository.go
@@ -64,6 +64,7 @@ func (r *PostRepository) Delete(postId int64) error {
 
 func (r *PostRepository) UpdatePost(title string, body string, postId int64) (*entities.Post, error) {
 	post := model.Post{
+		Id:    postId,
 		Title: title,
 		Body:  body,
 	}

--- a/backend/test/repositories/post_repository_test.go
+++ b/backend/test/repositories/post_repository_test.go
@@ -225,6 +225,7 @@ func TestUpdatePost(t *testing.T) {
 			post, err := repo.UpdatePost(tc.title, tc.body, tc.postId)
 			assert.Equal(t, tc.expectedErr, err)
 			if post != nil {
+				assert.Equal(t, tc.postId, post.Id)
 				assert.Equal(t, tc.title, post.Title)
 				assert.Equal(t, tc.body, post.Body)
 			}


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

## PRの概要
### 現状
投稿更新時、Web上で画面遷移ができずにエラーが発生していた

### 今回やったこと
投稿更新時のレスポンスにIDが含まれるようにした

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->

### 動作検証
![image](https://github.com/givery-bootcamp/dena-2024-team10/assets/21969328/a815d74c-4336-4656-9191-446f0efe8749)

### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
たむしゅんありがとう
- https://denatech.slack.com/archives/C071563EGH3/p1719545513332359?thread_ts=1719542211.806369&cid=C071563EGH3

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->