### PR TITLE
サインアップ後のサインイン時にHash化されていないPassを渡すように変更した

### DIFF
--- a/backend/internal/controllers/auth_controller.go
+++ b/backend/internal/controllers/auth_controller.go
@@ -59,7 +59,7 @@ func SignUp(ctx *gin.Context) {
 
 	signInUsecase := usecases.NewSignInUsecase(repository)
 
-	user, token, err := signInUsecase.Execute(user.Username, user.Password)
+	user, token, err := signInUsecase.Execute(user.Username, body.Password)
 	if err != nil {
 		ctx.Error(err)
 		return

--- a/backend/internal/usecases/signin_usecase.go
+++ b/backend/internal/usecases/signin_usecase.go
@@ -21,7 +21,7 @@ func NewSignInUsecase(r interfaces.UserRepository) *SignInUsecase {
 // Execute is the method to execute SignInUsecase
 // Check password and username contained in the request body
 // If the password and username are correct, return User entity and JWT token
-func (u *SignInUsecase) Execute(username, password string) (*entities.User, string, error) {
+func (u *SignInUsecase) Execute(username, nonHashedPassword string) (*entities.User, string, error) {
 	// Get user by username
 	user, err := u.repository.GetByUsername(username)
 	if err != nil {
@@ -33,7 +33,7 @@ func (u *SignInUsecase) Execute(username, password string) (*entities.User, stri
 		return nil, "", exception.ErrSigninFailed
 	}
 
-	err = utils.CheckPasswordHash(user.Password, password)
+	err = utils.CheckPasswordHash(user.Password, nonHashedPassword)
 	if err != nil {
 		return nil, "", exception.ErrSigninFailed
 	}


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

## PRの概要
### 現状
サインアップができない

### 今回やったこと
サインアップ後のサインイン時にHash化されていないPassを渡すように変更した

### やらなかったこと
元々SignUpUsecaseが問題なく通ってたのにレコードが追加されなかった謎の調査。Transactionは明示的にかけて無いはず。
**心当たりあったら教えて欲しい！**
- https://denatech.slack.com/archives/C071563EGH3/p1719552415428469?thread_ts=1719542211.806369&cid=C071563EGH3

### 動作検証
![image](https://github.com/givery-bootcamp/dena-2024-team10/assets/21969328/7f04d395-caf2-448a-8a6a-9d2580b2741f)
```
curl -H "Content-Type: application/json" -c cookie.txt -d '{"username":"newperson", "password":"password"}' http://localhost:9000/signup
{"id":32,"username":"newperson"}%      
```

### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->