### PR TITLE
ポスト更新時に更新対象がUserIDのポストになるバグを修正した

### DIFF
--- a/backend/internal/usecases/update_post_usecase.go
+++ b/backend/internal/usecases/update_post_usecase.go
@@ -31,5 +31,5 @@ func (u *UpdatePostUsecase) Execute(request schema.PostRequest, userId int64, po
 	if post.UserId != userId {
 		return nil, exception.ErrUnauthorizedToUpdatePost
 	}
-	return u.postRepository.UpdatePost(request.Title, request.Body, userId)
+	return u.postRepository.UpdatePost(request.Title, request.Body, postId)
 }


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

## PRの概要
### 現状
ポスト更新時に更新対象がUserIDのポストになる

### 今回やったこと
ポスト更新時に更新対象をPostIDに変更した

### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->

### 動作検証
| before | after | 
----|---- 
| ![スクリーンショット 2024-06-28 15 59 28](https://github.com/givery-bootcamp/dena-2024-team10/assets/21969328/280dca86-6152-4c16-b202-a6b61beac873) | ![スクリーンショット 2024-06-28 16 00 08](https://github.com/givery-bootcamp/dena-2024-team10/assets/21969328/b45460e4-4e53-46e1-956d-ea064183600f) |

### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->