### PR TITLE
bug-fix: 204のリクエストをzodios使って叩くとダメだということがわかったので、fetchに変えた

### DIFF
--- a/frontend/app/routes/posts.$postId.tsx
+++ b/frontend/app/routes/posts.$postId.tsx
@@ -1,8 +1,4 @@
-import {
-	type ActionFunctionArgs,
-	type LoaderFunctionArgs,
-	json,
-} from "@remix-run/node";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import {
 	Form,
 	Link,
@@ -11,10 +7,9 @@ import {
 	useParams,
 } from "@remix-run/react";
 import classNames from "classnames";
-import { useState } from "react";
 import formatDate from "utils/formatDate";
-import apiClient from "~/apiClient/apiClient";
-import Dialog, { useDialog } from "~/components/dialog";
+import apiClient, { API_BASE_URL } from "~/apiClient/apiClient";
+import { useDialog } from "~/components/dialog";
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
 	try {
@@ -48,19 +43,16 @@ export async function loader({ params, request }: LoaderFunctionArgs) {
 export async function action({ params, request }: ActionFunctionArgs) {
 	const postId = Number.parseInt(params.postId as string);
 	try {
-		await apiClient.deletePost(undefined, {
-			params: {
-				postId,
-			},
+		await fetch(`${API_BASE_URL}/posts/${postId}`, {
+			method: "DELETE",
 			headers: {
 				Cookie: request.headers.get("Cookie") as string,
 			},
 		});
 		return redirect("/");
 	} catch (e) {
-		return new Response((e as Error).message, {
-			status: 400,
-		});
+		console.error(e);
+		throw new Response(JSON.stringify(e), { status: 500 });
 	}
 }
 


### PR DESCRIPTION
## Issue 番号
<!-- あれば記入する -->

## PRの概要
### 現状
<!-- 解決するべき課題　なければなし -->
**怒りの投稿削除バグ原因判明レポート**
#### 原因
- swaggerでresponse 204 NoContentになっているものに対して、generatorが生成するzod型がz.void()であること
- そして、zodis clientが使ってるapi fetcherがaxiosであること
#### バグるまでの流れ
1. geneeratorがz.voidで生成する
1. zodiosがaxios使ってapi叩く
1. nullが帰ってくる
1. axiosがnullを勝手に“”(空文字)に変換しやがる
1. z.voidの方チェックに引っかかる
1. エラーを吐く
1. キモすぎる
#### 同じ204でも/signoutがバッグってない理由
ここはCookieうんぬんの関係で、fetch使って自分らでかいてるからバグってない

じゃーなんでMock相手やとエラーでらんのや
レスポンス変わらんぞこのやろう

### 今回やったこと
<!-- このPRでやったことの説明 -->
- delete postsのリクエスト投げてるとこをfetchに変えた
  - Web標準しか勝たん


### やらなかったこと
<!-- 別PRに分けた部分など　なければなし -->
- 他の204の対応
  - delete comments 
    - 対応時点でmainにマージされていなかったので

### 動作検証
<!-- テストの実行結果やPlaygroundの実行結果のスクリーンショット等 -->

### チェックリスト
<!-- レビュー依頼前に確認すること -->
- [ ] CIをPassしましたか？ 

## 資料
<!-- 参考にしたサイトURL　or　コンフルのURL -->

## レビュワーへの共有事項
<!-- 影響範囲や懸念事項 -->